### PR TITLE
DEV-1865 Use v0.1.0rc3 of meemoo-cloudevents lib

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -327,7 +327,7 @@ reference = "meemoo"
 
 [[package]]
 name = "meemoo-cloudevents"
-version = "0.1.0rc2"
+version = "0.1.0rc3"
 description = "Meemoo's implementation of CloudEvents"
 category = "main"
 optional = false
@@ -804,7 +804,7 @@ reference = "meemoo"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "93064d135ffb72b13cf441983dd44765b4155a237ebdac0bfbf7a439ab3a05ef"
+content-hash = "2054cd1187c92100d3cf364fc9ed8ad21c32643c33883062914108e759b797e8"
 
 [metadata.files]
 appdirs = [
@@ -987,8 +987,8 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 meemoo-cloudevents = [
-    {file = "meemoo-cloudevents-0.1.0rc2.tar.gz", hash = "md5:e08684aff5fff3b03a5181f0f8abd591"},
-    {file = "meemoo_cloudevents-0.1.0rc2-py3-none-any.whl", hash = "md5:17c3b776d66795fada31c99cce1e0464"},
+    {file = "meemoo-cloudevents-0.1.0rc3.tar.gz", hash = "md5:dfd34738992f485aaea646b59a7febae"},
+    {file = "meemoo_cloudevents-0.1.0rc3-py3-none-any.whl", hash = "md5:09950aa8513d9547053ee2b28db7ae91"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requests = "^2.25.1"
 retry = "^0.9.2"
 pulsar-client = "^2.8.1"
 hvac = "^0.11.2"
-meemoo-cloudevents = "0.1.0rc2"
+meemoo-cloudevents = "^0.1.0-rc.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"


### PR DESCRIPTION
This version contains an important fix for the `get_data()` method.