### PR TITLE
DEV-1940 Add source credentials option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 # Install curl
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends curl openssh-client
+RUN apt-get install -y --no-install-recommends curl
 
 # Install Poetry
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \


### PR DESCRIPTION
It is possible that you need credentials to access/transfer the source file.
Add an option to provide them in the cURL command via the "-u" parameter.