### PR TITLE
DEV-2131 Change name of temporary target subfolder

### DIFF
--- a/app/helpers/transfer.py
+++ b/app/helpers/transfer.py
@@ -157,7 +157,7 @@ class Transfer:
         self.dest_file_basename = os.path.basename(self.destination_path)
 
         self.dest_file_tmp_basename = f"{self.dest_file_basename}.tmp"
-        dest_folder_tmp_basename = f".{self.dest_file_basename}"
+        dest_folder_tmp_basename = f"{self.dest_file_basename}.part"
         self.dest_folder_tmp_dirname = os.path.join(
             self.dest_folder_dirname, dest_folder_tmp_basename
         )


### PR DESCRIPTION
File parts are send to a temporary subfolder in the target directory.
That temporary subfolder is a dotfolder. Apparently, the watchfolder
process picks up a dotfolder and potentially watches the files in that
folder. Change the folder to have the suffix `.part` so that the folder
doesn't get picked up.