### PR TITLE
DEV-2297 Add Vault namespace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ SSH_FREE_SPACE_PERCENTAGE=
 PULSAR_HOST=pulsar_host
 VAULT_URL=https://vault/
 VAULT_TOKEN=vault_token
+VAULT_NAMESPACE=namespace

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# S3 Transfer Service
+# Transfer Service
 
 ## Synopsis
 
@@ -24,7 +24,7 @@ There is an optional free space check in which the remote server needs to have a
 <details>
   <summary>Sequence diagram (click to expand)</summary>
 
-  ![S3 Transfer Service](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/viaacode/s3-transfer-service/main/docs/s3-t-s_sequence-diagram.plantuml&fmt=svg)
+  ![Transfer Service](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/viaacode/transfer-service/main/docs/transfer-service_sequence-diagram.plantuml&fmt=svg)
 
 </details>
 
@@ -32,7 +32,7 @@ There is an optional free space check in which the remote server needs to have a
 
 1. Clone this repository with:
 
-   `$ git clone https://github.com/viaacode/s3-transfer-service.git`
+   `$ git clone https://github.com/viaacode/transfer-service.git`
 
 2. Change into the new directory.
 
@@ -44,28 +44,54 @@ There is an optional free space check in which the remote server needs to have a
     You can use `!ENV ${EXAMPLE}` as a config value to make the application get the `EXAMPLE` environment variable.
 
 ### Running locally
-1. Install the external modules:
 
-    `$ poetry install`
+**Note**: As per the aforementioned requirements, this is a Python3
+application. Check your Python version with `python --version`. You may want to
+substitute the `python` command below with `python3` if your default Python version
+is < 3.
 
-2. Run the tests (and setting the values in `.env.example` first):
+1. Start by creating a virtual environment:
 
-    `$ export $(grep -v '^#' .env.example | xargs -0); poetry run pytest -v --cov=./app`
+    `$ python -m venv env`
 
-3. Run the application:
+2. Activate the virtual environment:
 
-    `$ poetry run python main.py`
+    `$ source env/bin/activate`
+
+3. Install the external modules:
+
+    ```
+    $ pip install -r requirements.txt \
+        --extra-index-url http://do-prd-mvn-01.do.viaa.be:8081/repository/pypi-all/simple \
+        --trusted-host do-prd-mvn-01.do.viaa.be
+    ```
+
+4. Run the tests (and set the values in `.env.example`) with:
+
+    To be able to run the tests, the test dependencies need to be installed as well:
+
+    ```
+    $ pip install -r requirements-test.txt
+    ```
+
+    Then run:
+
+    `$ export $(grep -v '^#' .env.example | xargs); pytest -v --cov=./app`
+
+5. Run the application:
+
+    `$ python main.py`
 
 ### Running using Docker
 
 1. Build the container:
 
-   `$ docker build -t s3-transfer-service:latest .`
+   `$ docker build -t transfer-service:latest .`
 
 2. Run the test container:
 
-   `$ docker run --env-file .env.example --rm --entrypoint python s3-transfer-service:latest -m pytest -v --cov=./app`
+   `$ docker run --env-file .env.example --rm --entrypoint python transfer-service:latest -m pytest -v --cov=./app`
 
 2. Run the container (with specified `.env` file):
 
-   `$ docker run --env-file .env --rm s3-transfer-service:latest`
+   `$ docker run --env-file .env --rm transfer-service:latest`

--- a/app/services/vault.py
+++ b/app/services/vault.py
@@ -12,7 +12,10 @@ config = config_parser.app_cfg
 class VaultClient:
     def __init__(self):
         self.client = hvac.Client(
-            url=config["vault"]["url"], verify=False, token=config["vault"]["token"]
+            url=config["vault"]["url"],
+            token=config["vault"]["token"],
+            namespace=config["vault"]["namespace"],
+            verify=False,
         )
 
         self.secrets = {}

--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,7 @@ app:
   vault:
     url: !ENV ${VAULT_URL}
     token: !ENV ${VAULT_TOKEN}
+    namespace: !ENV ${VAULT_NAMESPACE}
   pulsar:
     host: !ENV ${PULSAR_HOST}
     port: 6650

--- a/docs/transfer-service_sequence-diagram.plantuml
+++ b/docs/transfer-service_sequence-diagram.plantuml
@@ -1,8 +1,8 @@
-@startuml s3-transfer-service
+@startuml transfer-service
 
 autonumber
 
-title S3 Transfer Service
+title Transfer Service
 
 participant rabbit as "RabbitMQ"
 participant sts as "s3-transfer-service"

--- a/docs/transfer-service_sequence-diagram.plantuml
+++ b/docs/transfer-service_sequence-diagram.plantuml
@@ -5,15 +5,15 @@ autonumber
 title Transfer Service
 
 participant rabbit as "RabbitMQ"
-participant sts as "s3-transfer-service"
+participant self as "transfer-service"
 participant tra as "Remote Server"
 participant os as "Object Store"
 
-activate sts
-sts -> rabbit: Listen to queue
+activate self
+self -> rabbit: Listen to queue
 loop
-    rabbit -> sts: Transfer message request
-    sts -> tra: Connect via SSH
+    rabbit -> self: Transfer message request
+    self -> tra: Connect via SSH
     opt SSH_FREE_SPACE_PERCENTAGE && SSH_FILE_SYSTEM
         loop While not enough free space
             tra -> tra: Check free space

--- a/tests/services/test_vault.py
+++ b/tests/services/test_vault.py
@@ -20,11 +20,16 @@ class TestPulsarClient:
         """Check if the vault client got instantiated correctly."""
         vault_client = VaultClient()
         client.assert_called_once_with(
-            **{"url": "https://vault/", "verify": False, "token": "vault_token"}
+            **{
+                "url": "https://vault/",
+                "token": "vault_token",
+                "namespace": "namespace",
+                "verify": False,
+            }
         )
         assert len(vault_client.secrets) == 0
 
-    def test_fetch_secret(self, vault_client):
+    def test_fetch_secret(self, vault_client: VaultClient):
         path = "engine/name"
         assert path not in vault_client.secrets
         vault_client.fetch_secret(path)
@@ -33,24 +38,24 @@ class TestPulsarClient:
             **{"path": "name", "mount_point": "engine"}
         )
 
-    def test_get_username(self, vault_client):
+    def test_get_username(self, vault_client: VaultClient):
         path = "path"
         vault_client.secrets["path"] = {"data": {"username": "user"}, "metadata": {}}
 
         assert vault_client.get_username(path) == "user"
 
-    def test_get_password(self, vault_client):
+    def test_get_password(self, vault_client: VaultClient):
         path = "path"
         vault_client.secrets["path"] = {"data": {"password": "pass"}, "metadata": {}}
 
         assert vault_client.get_password(path) == "pass"
 
-    def test_get_username_key_error(self, vault_client):
+    def test_get_username_key_error(self, vault_client: VaultClient):
         path = "path"
         with pytest.raises(KeyError):
             vault_client.get_username(path)
 
-    def test_get_password_key_error(self, vault_client):
+    def test_get_password_key_error(self, vault_client: VaultClient):
         path = "path"
         with pytest.raises(KeyError):
             vault_client.get_password(path)


### PR DESCRIPTION
HCP Enterprise Vault uses namespaces by default. This must be included in the instantiation of the client.

All tests pass. Tested against the live Vaults, both old and new, also with an empty string as namespace (for backwards compatibility):

```
NAMESPACE = ""
NAMESPACE = "admin"

client = hvac.Client(url=URL,token=TOKEN,namespace=NAMESPACE,verify=False,)
```

Included: some changes to documentation.