### PR TITLE
DEV-2495 Specify unicode encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 # Make a new group and user so we don't run as root.
 RUN addgroup --system appgroup && adduser --system appuser --ingroup appgroup

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There is an optional free space check in which the remote server needs to have a
 
 - Git
 - Docker (optional)
-- Python 3.8+
+- Python 3.10+
 - Access to the [meemoo PyPi](http://do-prd-mvn-01.do.viaa.be:8081)
 - Poetry
 

--- a/app/helpers/transfer.py
+++ b/app/helpers/transfer.py
@@ -317,9 +317,7 @@ class Transfer:
                 raise TransferException
         elif source_url_parsed.scheme in ("ftp",):
             try:
-                with FTP(
-                    host=source_url_parsed.netloc,
-                ) as ftp:
+                with FTP(host=source_url_parsed.netloc, encoding="utf-8") as ftp:
                     ftp.login(
                         user=self.source_username,
                         passwd=self.source_password,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ idna==2.10
 meemoo-cloudevents==0.1.0rc3
 paramiko==2.7.2
 pika==1.2.0
-pulsar-client==2.8.1
+pulsar-client==2.10.2
 py==1.10.0
 pycparser==2.20
 pynacl==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bcrypt==3.2.0
 certifi==2020.12.5
-cffi==1.14.5
+cffi==1.16.0
 chardet==4.0.0
 cryptography==3.4.6
 decorator==4.4.2
@@ -14,7 +14,7 @@ py==1.10.0
 pycparser==2.20
 pynacl==1.4.0
 python-json-logger==2.0.1
-pyyaml==5.4.1
+pyyaml==6.0.1
 requests==2.25.1
 retry==0.9.2
 six==1.15.0


### PR DESCRIPTION
Upgrade to Python 3.10 in order to specify the encoding for directories and filenames when making use of the FTP library.

Also, bump pulsar-client as version 2.8.1 was not available anymore.